### PR TITLE
add support for OTF files and use argparse instead of optparse

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,11 +3,11 @@
 pkgname=makefontpkg
 pkgver=20130816
 pkgrel=1
-pkgdesc="Tool to create packages from TrueType-Fonts"
+pkgdesc="Tool to create packages from TrueType-Fonts & OpenType-Fonts"
 arch=('x86_64' 'i686')
 url="http://github.com/misterdanb/makefontpkg"
 license=('Beerware')
-depends=('python2')
+depends=('python')
 makedepends=('git')
 options=('!strip' '!emptydirs')
 source=('makefontpkg::git://github.com/misterdanb/makefontpkg.git')

--- a/makefontpkg
+++ b/makefontpkg
@@ -1,143 +1,155 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
 import os
-import sys
 import hashlib
 
 from subprocess import call
-from optparse import OptionParser
+from argparse import ArgumentParser
+
 
 def main():
-	parser = OptionParser()
-	
-	parser.add_option("-s", "--source",
-	                  action="store_true", dest="source", default=False,
-	                  help="make a source package for the AUR")
+    parser = ArgumentParser(description="Create font package from TTF or OTF file", prog="makefontpkg")
 
-        parser.add_option("-i", "--install",
-                          action="store_true", dest="install", default=False,
-                          help="directly install the package with pacman")
-	
-	(options, args) = parser.parse_args()
-	
-	if len(args) == 1:
-		fontpath = args[0]
-		
-		fontfile = os.path.basename(fontpath)
-		fontname, fontextension = os.path.splitext(fontfile)
-		
-		if os.path.exists(fontpath) and fontextension.lower() == ".ttf":
-			call(["cp", fontpath, "./"])
-			
-			generatepkgbuild(fontpath)
-			generatedotinstall(fontpath)
-			
-                        if options.install:
-                            makepkg()
+    parser.add_argument("-s", "--source",
+                        action="store_true", dest="source", default=False,
+                        help="make a source package for the AUR")
 
-                            call(["sudo", "pacman", "-U", fontname + "-1.0-1-any.pkg.tar.xz"])
-			elif options.source:
-				makepkgsource()
-			else:
-				makepkg()
-			
-			clean(fontpath)
-		else:
-			print "Are you really sure this file is a true type font and exists?"
-	else:
-		print "Please pass exactly one argument!"
+    parser.add_argument("-i", "--install",
+                        action="store_true", dest="install", default=False,
+                        help="directly install the package with pacman")
+
+    parser.add_argument("font_file_path", nargs=1, action="store",
+                        help="path/to/.ttf/or/.otf/file")
+
+    args = parser.parse_args()
+
+    fontpath = args.font_file_path[0]
+    fontfile = os.path.basename(fontpath)
+    fontname, fontextension = os.path.splitext(fontfile)
+    fonttype = fontextension[1:].upper()
+
+    if os.path.exists(fontpath) and (fonttype == "TTF" or fonttype == "OTF"):
+        call(["cp", fontpath, "./"])
+
+        generatepkgbuild(fontpath)
+        generatedotinstall(fontpath)
+
+        if args.install:
+            makepkg()
+
+            call(["sudo", "pacman", "-U", fontname + "-1.0-1-any.pkg.tar.xz"])
+        elif args.source:
+            makepkgsource()
+        else:
+            makepkg()
+
+        clean(fontpath)
+    else:
+        print("Are you really sure this file is a TrueType or OpenType font and exists?")
+
 
 def generatepkgbuild(fontpath):
-	pkgbuild = ("pkgname=$$FONTNAME$$\n" + \
-	            "pkgver=1.0\n" + \
-	            "pkgrel=1\n" + \
-	            "depends=('fontconfig' 'xorg-font-utils')\n" + \
-	            "pkgdesc=\"$$FONTNAME$$ custom font\"\n" + \
-	            "arch=('any')\n" + \
-	            "\n" + \
-	            "source=($$FONTFILE$$)\n" + \
-	            "md5sums=(\"$$MD5SUM$$\")\n" + \
-	            "\n" + \
-	            "install=$pkgname.install\n" + \
-	            "\n" + \
-	            "package() {\n" + \
-	            "  install -d \"$pkgdir/usr/share/fonts/TTF\"\n" + \
-	            "  cp -dpr --no-preserve=ownership \"$srcdir/$$FONTFILE$$\" \"$pkgdir/usr/share/fonts/TTF/\"\n") + \
-	            "}\n"
-	
-	fontfile = os.path.basename(fontpath)
-	fontname, _ = os.path.splitext(fontfile)
-	md5sum = hashfile(fontpath, hashlib.md5())
-	
-	pkgbuild = pkgbuild.replace("$$FONTFILE$$", fontfile)
-	pkgbuild = pkgbuild.replace("$$FONTNAME$$", fontname)
-	pkgbuild = pkgbuild.replace("$$MD5SUM$$", md5sum)
-	
-	openedpkgbuild = open("PKGBUILD", "w+")
-	openedpkgbuild.write(pkgbuild)
-	openedpkgbuild.close()
+    pkgbuild = ("pkgname=$$FONTNAME$$\n" +
+                "pkgver=1.0\n" +
+                "pkgrel=1\n" +
+                "depends=('fontconfig' 'xorg-font-utils')\n" +
+                "pkgdesc=\"$$FONTNAME$$ custom font\"\n" +
+                "arch=('any')\n" +
+                "\n" +
+                "source=($$FONTFILE$$)\n" +
+                "md5sums=(\"$$MD5SUM$$\")\n" +
+                "\n" +
+                "install=$pkgname.install\n" +
+                "\n" +
+                "package() {\n" +
+                "  install -d \"$pkgdir/usr/share/fonts/$$FONTTYPE$$\"\n" +
+                "  cp -dpr --no-preserve=ownership \"$srcdir/$$FONTFILE$$\" \"$pkgdir/usr/share/fonts/$$FONTTYPE$$/\"\n" +
+                "}\n")
+
+    fontfile = os.path.basename(fontpath)
+    fontname, fontextension = os.path.splitext(fontfile)
+    fonttype = fontextension[1:].upper()
+    md5sum = hashfile(fontpath, hashlib.md5())
+
+    pkgbuild = pkgbuild.replace("$$FONTFILE$$", fontfile)
+    pkgbuild = pkgbuild.replace("$$FONTNAME$$", fontname)
+    pkgbuild = pkgbuild.replace("$$MD5SUM$$", md5sum)
+    pkgbuild = pkgbuild.replace("$$FONTTYPE$$", fonttype)
+
+    openedpkgbuild = open("PKGBUILD", "w+")
+    openedpkgbuild.write(pkgbuild)
+    openedpkgbuild.close()
+
 
 def hashfile(fontpath, hasher, blocksize=65536):
-	openedfont = open(fontpath, "rb")
-	filebuffer= openedfont.read(blocksize)
-	
-	while len(filebuffer) > 0:
-		hasher.update(filebuffer)
-		filebuffer = openedfont.read(blocksize)
-	
-	openedfont.close()
-	
-	return hasher.hexdigest()
+    openedfont = open(fontpath, "rb")
+    filebuffer = openedfont.read(blocksize)
+
+    while len(filebuffer) > 0:
+        hasher.update(filebuffer)
+        filebuffer = openedfont.read(blocksize)
+
+    openedfont.close()
+
+    return hasher.hexdigest()
+
 
 def generatedotinstall(fontpath):
-	dotinstall = ("post_install() {\n" + \
-	              "  echo -n \"Updating font cache... \"\n" + \
-	              "  fc-cache -fs > /dev/null\n" + \
-	              "  mkfontscale /usr/share/fonts/TTF /usr/share/fonts/Type1\n" + \
-	              "  mkfontdir /usr/share/fonts/TTF /usr/share/fonts/Type1\n" + \
-	              "  echo \"Done. \"\n" + \
-	              "}\n" + \
-	              "\n" + \
-	              "post_upgrade() {\n" + \
-	              "  post_install\n" + \
-	              "}\n" + \
-	              "\n" + \
-	              "post_remove() {\n" + \
-	              "  post_install\n" + \
-	              "}\n")
-	
-	fontfile = os.path.basename(fontpath)
-	fontname, _ = os.path.splitext(fontfile)
-	
-	openeddotinstall = open(fontname + ".install", "w+")
-	openeddotinstall.write(dotinstall)
-	openeddotinstall.close()
+    dotinstall = ("post_install() {\n" +
+                  "  echo -n \"Updating font cache... \"\n" +
+                  "  fc-cache -fs > /dev/null\n" +
+                  "  mkfontscale /usr/share/fonts/$$FONTTYPE$$ /usr/share/fonts/Type1\n" +
+                  "  mkfontdir /usr/share/fonts/$$FONTTYPE$$ /usr/share/fonts/Type1\n" +
+                  "  echo \"Done. \"\n" +
+                  "}\n" +
+                  "\n" +
+                  "post_upgrade() {\n" +
+                  "  post_install\n" +
+                  "}\n" +
+                  "\n" +
+                  "post_remove() {\n" +
+                  "  post_install\n" +
+                  "}\n")
+
+    fontfile = os.path.basename(fontpath)
+    fontname, fontextension = os.path.splitext(fontfile)
+    fonttype = fontextension[1:].upper()
+
+    dotinstall = dotinstall.replace("$$FONTTYPE$$", fonttype)
+
+    openeddotinstall = open(fontname + ".install", "w+")
+    openeddotinstall.write(dotinstall)
+    openeddotinstall.close()
+
 
 def makepkg():
-	call(["makepkg", "-f"])
+    call(["makepkg", "-f"])
+
 
 def makepkgsource():
-	call(["makepkg", "-f", "--source"])
+    call(["makepkg", "-f", "--source"])
+
 
 def clean(fontpath):
-	fontfile = os.path.basename(fontpath)
-	fontname, _ = os.path.splitext(fontfile)
-	
-	if os.path.exists("src"):
-		call(["rm", "-r", "src"])
-	
-	if os.path.exists("pkg"):
-		call(["rm", "-r", "pkg"])
-	
-	if os.path.exists("PKGBUILD"):
-		call(["rm", "PKGBUILD"])
-	
-	if os.path.exists(fontname + ".install"):
-		call(["rm", fontname + ".install"])
+    fontfile = os.path.basename(fontpath)
+    fontname, _ = os.path.splitext(fontfile)
 
-if __name__=='__main__':
-	try:
-		main()
-	except KeyboardInterrupt:
-		print "Interrupted... "
+    if os.path.exists("src"):
+        call(["rm", "-r", "src"])
+
+    if os.path.exists("pkg"):
+        call(["rm", "-r", "pkg"])
+
+    if os.path.exists("PKGBUILD"):
+        call(["rm", "PKGBUILD"])
+
+    if os.path.exists(fontname + ".install"):
+        call(["rm", fontname + ".install"])
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("Interrupted... ")


### PR DESCRIPTION
- optparse is deprecated, argparse is recommended
- made some changes for PEP8
  - tab = 4 spaces
  - no need for `\` in `()`
- move from python 2 to python 3
