### PR TITLE
Change default naming to comply with arch wiki recommendation

### DIFF
--- a/makefontpkg
+++ b/makefontpkg
@@ -114,7 +114,7 @@ def main():
     # parse and sanitize the package name
     pkgname = args.name
     if pkgname is None:
-        pkgname = fontname
+        pkgname = fonttype.lower() + '-' + fontname
     pkgname = scrubpkgname(pkgname)
 
     # parse and validate the package version and release number


### PR DESCRIPTION
With this pull request,
`makefontpkg fontname.ttf` will lead to a package named `ttf-fontname` instead of just `fontname`